### PR TITLE
Perl5.26.3 updates

### DIFF
--- a/Chex.pm
+++ b/Chex.pm
@@ -10,7 +10,8 @@ package Chex;
 
 use RDB;
 use English;
-use POSIX qw(tmpnam);
+#use POSIX qw(tmpnam);
+use File::Temp qw(tempfile);
 #use lib '/proj/sot/ska/lib/site_perl';
 #use Ska::Convert qw(date2time time2date);
 use Convert qw(date2time time2date);
@@ -357,7 +358,7 @@ sub update {
 
 
 # Output complete history of Chandra Expected state
-    $tmp_out_file = tmpnam(); 
+    $tmp_out_file = (tempfile())[1];
     $out_rdb = new RDB;
     $out_rdb->open($tmp_out_file, ">") or die "Couldn't open $tmp_out_file\n";
     $out_rdb->init( map {$state_var[$_] => $state_format[$_]} (0..$#state_var) );

--- a/tlogr_linux.pl
+++ b/tlogr_linux.pl
@@ -7,6 +7,11 @@
 #  to force update, even on old data, use -f option.
 #print "Run tlogr\n";
 #exit;
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0)); # updates @INC with path to executable
+
 use snap;
 
 # produce a Chandra status snapshot


### PR DESCRIPTION
Files changed: Chex.pm, tlogr_linux.pl.

Chex.pm - accounted for tmpnam deprecated and later removed from POSIX.

tlogr_linux.pl - implicitly added the working directory to @INC.
