### PR TITLE
Remove obsolete email address from acorn notifications

### DIFF
--- a/run-acorn.pl
+++ b/run-acorn.pl
@@ -52,7 +52,7 @@ if (!@a) {
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
     #open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
-    open MAIL, "|mailx -s acorn lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
     print MAIL "$host acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";


### PR DESCRIPTION
Replace  obsolete email address with valid email addresses for acorn notifications.