### PR TITLE
Disable HRC alert

### DIFF
--- a/check_state_alerts.pm
+++ b/check_state_alerts.pm
@@ -961,7 +961,7 @@ sub shldart {
     }
     $tnum++;
     if ($tnum == 3) {
-      send_hrc_shld_alert($val);
+      #send_hrc_shld_alert($val);
     }
     if ($tnum <= 3) {
       open (TF, ">$tfile");


### PR DESCRIPTION
This PR disables the HRC alert in <code>check_state_alerts.pm</code> (the module used in communication between the primary and the secondary). This PR makes the repository consistent with the code that is currently running.
