### PR TITLE
Added mtadude to MTA-only notifications

### DIFF
--- a/check_state.pm
+++ b/check_state.pm
@@ -1386,7 +1386,8 @@ sub send_sim_unsafe_alert {
     print FILE "This message sent to swolk, malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@ipa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {

--- a/check_state_alerts.pm
+++ b/check_state_alerts.pm
@@ -1386,7 +1386,8 @@ sub send_sim_unsafe_alert {
     print FILE "This message sent to swolk, malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@ipa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {

--- a/check_state_test.pm
+++ b/check_state_test.pm
@@ -1292,7 +1292,8 @@ sub send_107_alert {
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s SCS107 brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'SCS107 TEST'  lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'SCS107 TEST'  lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'SCS107 TEST'  mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s SCS107 brad\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
@@ -1354,7 +1355,8 @@ sub send_nsun_alert {
 
     #open MAIL, "|mailx -s NSUN brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s NSUN brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'NSUN TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'NSUN TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'NSUN TEST' mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s NSUN brad\@head.cfa.harvard.edu operators\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
@@ -1384,7 +1386,8 @@ sub send_sim_unsafe_alert {
     print FILE "This message sent to malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s 'UNSAFE! BUOCC ' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'UNSAFE! BUOCC ' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'UNSAFE! BUOCC ' mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s SIM_UNSAFE! brad\@head.cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
@@ -1415,7 +1418,8 @@ sub send_hrc_shld_alert {
     #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s 'HRC SHIELD' sot_lead\@head.cfa.harvard.edu brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'HRC SHIELD TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'HRC SHIELD TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'HRC SHIELD TEST' mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1482,7 +1486,8 @@ sub send_brit_alert {
 
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'BRIT ' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'BRIT ' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'BRIT ' mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s BRIT brad\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s BRIT brad\@head.cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu";
@@ -1546,7 +1551,8 @@ sub send_cpe_alert {
     close FILE;
 
     #open MAIL, "|mailx -s CPEstat brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'CPEstat'  lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'CPEstat'  lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'CPEstat'  mtadude\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1609,7 +1615,8 @@ sub send_fmt_alert {
 
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s 'SIM FMT5: telecon 111165\# now' brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'FMT5'  lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'FMT5'  lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'FMT5'  mtadude\@cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
@@ -1672,7 +1679,8 @@ sub send_gyro_alert {
     close FILE;
 
     #open MAIL, "|mailx -s AIRU1G1I brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
-    open MAIL, "|mailx -s 'AIRU1G1I BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'AIRU1G1I BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'AIRU1G1I BUOCC TEST' mtadude\@cfa.harvard.edu";
     #open MAIL, "|mailx -s AIRU1G1I brad\@head.cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
@@ -1699,7 +1707,8 @@ sub send_ctxpwr_alert {
     close FILE;
 
     #open MAIL, "|mailx -s CTXPWR brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'CTXPWR BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'CTXPWR BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'CTXPWR BUOCC TEST' mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1725,7 +1734,8 @@ sub send_ctxv_alert {
     close FILE;
 
     #open MAIL, "|mailx -s CTXV brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'CTXV BUOCC TEST'  lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'CTXV BUOCC TEST'  lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'CTXV BUOCC TEST'  mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1778,7 +1788,8 @@ sub send_pline03t_alert {
     close FILE;
 
     #open MAIL, "|mailx -s PLINE03T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'PLINE03T BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'PLINE03T BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'PLINE03T BUOCC TEST' mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1804,7 +1815,8 @@ sub send_pline04t_alert {
     close FILE;
 
     #open MAIL, "|mailx -s PLINE04T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'PLINE04T BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'PLINE04T BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'PLINE04T BUOCC TEST' mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1830,7 +1842,8 @@ sub send_aacccdpt_yellow_alert {
     close FILE;
 
     #open MAIL, "|mailx -s AACCCDPT brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'AACCCDPT BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'AACCCDPT BUOCC TEST' lpulgarinduque\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'AACCCDPT BUOCC TEST' mtadude\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;

--- a/tlogr_linux.pl
+++ b/tlogr_linux.pl
@@ -93,7 +93,8 @@ if (! $aos) {
     `cp $check_comm_file $check_comm_sent`;
     #`cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu`;
     #`cat $check_comm_file | mailx -s 'check_comm' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu jnichols\@cfa.harvard.edu`;
-    `cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu`;
+    #`cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu`;
+    `cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu mtadude\@cfa.harvard.edu`;
   } # if (-s $check_comm_file && -s $check_comm_file_bu && 
   # give backup control of alerts, in case it sees data
   if (! -e "/home/mta/Snap/.alerts_bu") {
@@ -112,7 +113,8 @@ if (-e "/home/mta/Snap/.alerts_bu") {
 } # if (-e "/home/mta/Snap/.alerts_bu") {
 # start check_comm all clear e-mails
 if (-s $check_comm_file) {
-  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+  #open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu mtadude\@cfa.harvard.edu";
   print MAIL "Rhodes data flow resumed.\n";
   close MAIL;
   unlink $check_comm_file;
@@ -122,7 +124,8 @@ if (-s $check_comm_file) {
 if (! -s $check_comm_file && -s $check_comm_sent) {
   #open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
   #open MAIL, "| mailx -s 'check_comm' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu jnichols\@cfa.harvard.edu";
-  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+  #open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu lpulgarinduque\@cfa.harvard.edu";
+  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu mtadude\@cfa.harvard.edu";
   print MAIL "Real-time data flow has resumed.\n";
   close MAIL;
   unlink $check_comm_sent;


### PR DESCRIPTION
Notifications which are send to MTA only will now be sent to mtadude, in addition to the MTA individuals. Affected files: <code>check_state.pm</code>, <code>check_state_alerts.pm</code>,  <code>check_state_noalerts.pm</code>, and  <code>tlogr_linux.pl</code>.