### PR TITLE
Disabled plotting with IDL

### DIFF
--- a/tlogr_linux.pl
+++ b/tlogr_linux.pl
@@ -258,7 +258,7 @@ close SF;
 
 unlink $lock;
 
-`/opt/local/bin/idl plot > /dev/null`;  # make plots
+#`/opt/local/bin/idl plot > /dev/null`;  # make plots
 #end
 #replace cronjob sleep 60;
 #replace cronjob }


### PR DESCRIPTION
Disabled call to IDL plotting routines. This makes <code>*.pro</code> files obsolete. Plots of trends are now accomplished with the python/maude CSH software.