### PR TITLE
Update IPCL path

### DIFF
--- a/run-acorn.pl
+++ b/run-acorn.pl
@@ -40,7 +40,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    open MAIL, "|mailx -s acorn msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn mtadude\@cfa.harvard.edu";
     print MAIL "$host acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/run-acorn.pl
+++ b/run-acorn.pl
@@ -20,9 +20,10 @@ $filesize = 500;
 
 @mta_data = qw(/home/ascds/DS.release/config/mta/data /data/mta2/pallen/acorn-1.3/groups /home/swolk/acorn/groups);
 $ENV{ASCDS_CONFIG_MTA_DATA} = (-e $mta_data[0])? $mta_data[0] : $mta_data[1]; 
+@ipcl = qw(/home/ascds/DS.release/config/tp_template/P016 /data/mta4/www/Snapshot/P011)
 # use custom IPCL dir to get uncalibrated SHLDART, DETART, but
 #  everything else calibrated
-@ipcl = qw(/data/mta4/www/Snapshot/P011 /data/mta4/www/Snapshot/P009);
+#@ipcl = qw(/data/mta4/www/Snapshot/P011 /data/mta4/www/Snapshot/P009);
 $ENV{IPCL_DIR} = (-e $ipcl[0])? $ipcl[0] : $ipcl[1];
 $ENV{LD_LIBRARY_PATH} = '/home/ascds/DS.release/lib:/home/ascds/DS.release/ots/lib:/soft/SYBASE_OSRV16.0/OCS-16_0/lib:/home/ascds/DS.release/otslib:/opt/X11R6/lib:/usr/lib64/alliance/lib:$LD_LIBRARY_PATH';
 chdir $work_dir or die "Cannot cd to $work_dir\n";

--- a/run-acorn.pl
+++ b/run-acorn.pl
@@ -8,20 +8,12 @@
 # April 2000
 
 $uid = "mta";
-#$work_dir = "/proj/ascwww/AXAF/extra/science/cgi-gen/mta/Snap";
 $work_dir = "/data/mta4/www/Snapshot";
 $pid_file = "$work_dir/racorn.pid";
-#@acorn = qw(/home/ascds/DS.release/bin/acorn /proj/cm/Release/install.DS7.6.9/bin/acorn /data/mta2/pallen/acorn-1.33/acorn /home/swolk/acorn/src1-3/acorn);
 @acorn = qw(/home/ascds/DS.release/bin/acorn);
-#@acorn = qw(/export/acis-flight/primary/acorn-1.33/acorn);
-#@acorn = qw(/home/acisdude/real-time/back-up/acorn-1.33/acorn);
-#@acorn = qw(/home/mta/ACORN/acorn1.52);
 $acorn_exe = (-e $acorn[0])? $acorn[0] : $acorn[1];
-#$UDP_port = "11111"; # eno's acorn feed
 $UDP_port = "11112"; # c3po-v
-#$UDP_port = "11113"; # temp feed from forbin bds 09/11/03
 $msids = "$work_dir/chandra-msids.list";
-#$msids = "$work_dir/msids.list";
 $filesize = 500;
 
 # set environment variables for acorn
@@ -31,8 +23,6 @@ $ENV{ASCDS_CONFIG_MTA_DATA} = (-e $mta_data[0])? $mta_data[0] : $mta_data[1];
 # use custom IPCL dir to get uncalibrated SHLDART, DETART, but
 #  everything else calibrated
 @ipcl = qw(/data/mta4/www/Snapshot/P011 /data/mta4/www/Snapshot/P009);
-##@ipcl = qw(/data/mta4/www/Snapshot/P009 /home/ascds/DS.release/config/tp_template/P011/ /home/ascds/swolk/IPCL/P008 /home/swolk/acorn/ODB);
-#@ipcl = qw(/home/ascds/DS.release/config/tp_template/P011/ /home/ascds/swolk/IPCL/P008 /home/swolk/acorn/ODB);
 $ENV{IPCL_DIR} = (-e $ipcl[0])? $ipcl[0] : $ipcl[1];
 $ENV{LD_LIBRARY_PATH} = '/home/ascds/DS.release/lib:/home/ascds/DS.release/ots/lib:/soft/SYBASE_OSRV16.0/OCS-16_0/lib:/home/ascds/DS.release/otslib:/opt/X11R6/lib:/usr/lib64/alliance/lib:$LD_LIBRARY_PATH';
 chdir $work_dir or die "Cannot cd to $work_dir\n";
@@ -45,13 +35,11 @@ while (<PIDF>) { @pinfo = split };
 # get the PID for the currently running acorn process (if any)
 
 @p = `/bin/ps -auxwww | grep $uid`;
-#@a = grep /$acorn_exe.+$work_dir/, @p;
 @a = grep /$acorn_exe.+$msids/, @p;
 if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    #open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     open MAIL, "|mailx -s acorn msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
     print MAIL "$host acorn dead. restarting. \n\n"; # current version
     close MAIL;

--- a/run-acorn.pl
+++ b/run-acorn.pl
@@ -20,7 +20,7 @@ $filesize = 500;
 
 @mta_data = qw(/home/ascds/DS.release/config/mta/data /data/mta2/pallen/acorn-1.3/groups /home/swolk/acorn/groups);
 $ENV{ASCDS_CONFIG_MTA_DATA} = (-e $mta_data[0])? $mta_data[0] : $mta_data[1]; 
-@ipcl = qw(/home/ascds/DS.release/config/tp_template/P016 /data/mta4/www/Snapshot/P011)
+@ipcl = qw(/home/ascds/DS.release/config/tp_template/P016 /data/mta4/www/Snapshot/P011);
 # use custom IPCL dir to get uncalibrated SHLDART, DETART, but
 #  everything else calibrated
 #@ipcl = qw(/data/mta4/www/Snapshot/P011 /data/mta4/www/Snapshot/P009);


### PR DESCRIPTION
This PR updates the IPCL path for <code>acorn</code> from a local MTA P011 version to the ASCDS P016 version from Nov 2021. Affected files: <code>run-acorn.pl</code> running on the primary MTA machine. Similar changed will be completed for <code>acorn</code> running on the secondary and BUOCC MTA machines.

Additional changes to  <code>run-acorn.pl</code> submitted in this PR include:
- replacing hardcoded email addresses with mtadude mailing list
- removing obsolete commented lines