### PR TITLE
SHLDART, DETART calibration

### DIFF
--- a/comps.pm
+++ b/comps.pm
@@ -149,8 +149,13 @@ sub do_comps {
   # https://cxc.harvard.edu/contrib/juda/memos/FN443_HRC_in_RADMON.pdf
   # https://cxc.harvard.edu/contrib/juda/memos/radmon/mcp_total_rate_threshold.html
   # https://github.com/chandra-mta/mtanb/blob/g16-hrc-proxy/g16-hrc-proxy/norm_2detart_2shldart.ipynb
-  ${$h{"2SHLDBRT"}}[1] = int(${$h{"2SHLDBRT"}}[1] / 256);
-  ${$h{"2DETBRT"}}[1] = floor(log(${$h{"2DETBRT"}}[1] + 1) / log(2));
+
+  #With the transition from the custom MTA IPCL with uncalibrated SHLDART, DETART to live ASCDS IPCL P016 with calibration
+  #this transformation back to high-order bytes is now handled in the acorn telemetry processing
+  #Therefore this scaling is already performed
+  
+  #${$h{"2SHLDBRT"}}[1] = int(${$h{"2SHLDBRT"}}[1] / 256);
+  #${$h{"2DETBRT"}}[1] = floor(log(${$h{"2DETBRT"}}[1] + 1) / log(2));
 
   $utc = `date -u +"%Y:%j:%T (%b%e)"`;
   chomp $utc;


### PR DESCRIPTION
With the transition from the custom MTA IPCL with uncalibrated SHLDART, DETART to live ASCDS IPCL P016 with calibration, this transformation back to high-order bytes is now handled in the acorn telemetry processing. Therefore this scaling is already performed.

Calibration found in `/data/mta4/www/Snapshot/P011/tpp.txt` (Old usage)
"2DETART",1,1,0,255.0;
"2SHLDART",1,1,0,255.0;

Calibration found in `/home/ascds/DS.release/config/tp_template/P016/tpp.txt` (New usage)
"2DETART",1,2,255,65279.0;
"2SHLDART",1,2,255,65279.0;
