### PR TITLE
up the time_curr check limit

### DIFF
--- a/check_state.pm
+++ b/check_state.pm
@@ -1890,7 +1890,7 @@ sub time_curr {
   use Time::TST_Local;
   # return 1 if $time is within $tlim seconds of current time
   #  else return 0
-  $tlim = 120;
+  $tlim = 600;
   $time = $_[0];
   my $t1998 = 883612800.0;
   @now = gmtime();

--- a/check_state_alerts.pm
+++ b/check_state_alerts.pm
@@ -1890,7 +1890,7 @@ sub time_curr {
   use Time::TST_Local;
   # return 1 if $time is within $tlim seconds of current time
   #  else return 0
-  $tlim = 120;
+  $tlim = 600;
   $time = $_[0];
   my $t1998 = 883612800.0;
   @now = gmtime();

--- a/check_state_noalerts.pm
+++ b/check_state_noalerts.pm
@@ -1879,7 +1879,7 @@ sub time_curr {
   use Time::TST_Local;
   # return 1 if $time is within $tlim seconds of current time
   #  else return 0
-  $tlim = 120;
+  $tlim = 600;
   $time = $_[0];
   my $t1998 = 883612800.0;
   @now = gmtime();

--- a/check_state_test.pm
+++ b/check_state_test.pm
@@ -1910,7 +1910,7 @@ sub time_curr {
   use Time::TST_Local;
   # return 1 if $time is within $tlim seconds of current time
   #  else return 0
-  $tlim = 120;
+  $tlim = 600;
   $time = $_[0];
   my $t1998 = 883612800.0;
   @now = gmtime();


### PR DESCRIPTION
This PR increases the time_curr cutoff limit in checking whether the data line being processes is sufficiently current.