### PR TITLE
Repath Snapshot CRMsummary.dat file.

### DIFF
--- a/snap.cgi
+++ b/snap.cgi
@@ -91,6 +91,7 @@ $top = (open SF, './chandra.snapshot')? <SF> : '';
 # read the current proton flux info
 
  #$pfile = '/proj/rac/ops/CRM2/CRMsummary.dat';
+ # Reads current web directory file copied by the tlogr_linux.pl script.
  $pfile = './CRMsummary.dat';  # it is now copied over for DMZ transistion 11/16/10 bds
  open FF, $pfile;
  while (<FF>) {$fluxinfo .= $_};

--- a/snap.pm
+++ b/snap.pm
@@ -165,7 +165,7 @@ sub get_curr {
 
   # read the CRM fluence - replaces F_ACE in snapshot May 2001
   #####$fluf = "/proj/rac/ops/CRM3/CRMsummary.dat";
-  $fluf = "/data/mta4/proj/rac/ops/CRM3/CRMsummary.dat";        #--- ti 10/06/15
+  $fluf = "/data/mta4/www/RADIATION/CRM3/CRMsummary.dat"; # Updates to pathing to latest supported file instance 09/16/25 WA
   if (open FF, $fluf) {
       @ff = <FF>;
       @fl = split ' ',$ff[-1];

--- a/tlogr_linux.pl
+++ b/tlogr_linux.pl
@@ -31,7 +31,7 @@ $check_comm_file_bu="/home/mta/Snap/check_comm_fail_bu";
 $check_comm_sent="/home/mta/Snap/check_comm_sent";
 
 #`cp /proj/rac/ops/CRM3/CRMsummary.dat $web_dir`;   # copy so DMZ can see it 11/16/10 bds
-`cp /proj/rac/ops/CRM3/CRMsummary.dat $web_dir`;   # copy so DMZ can see it 11/16/10 bds
+`cp /data/mta4/www/RADIATION/CRM3/CRMsummary.dat $web_dir`;   # copy from web to current web directory. DMZ visible 09/16/25 WA
 
 my @ftype = qw(ACA CCDM EPHIN EPS PCAD IRU SIM-OTG SI TEL EPS-SFMT NORM-SFMT);
 


### PR DESCRIPTION
Update the pathing to the file instance of the CRMsummary.dat file in use by Snapshot. The new path goes to the officially supported python-generated instance of the CRMsummary.dat file path.

Note that no change to the algorithmic approach of how Snapshot operates has been made. tlogr_linux.pl still copies a version of the CRMsummary.dat file into the current web directory of the Snapshot software. snap.pm still paths directly to a non-copied instance of the CRMsummary.dat file. snap.cgi still paths to the CRMsummary.dat file in the current web directory of the Snapshot software.

This PR will be tested functionally by running on the mta@luke-v BUOCC instance of the Snapshot software.